### PR TITLE
Set hostname to reach the ESP32 easily

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
   "ssid": "YOUR_SSID",
-  "psk": "YOUR_AP_PASSWORD"
+  "psk": "YOUR_AP_PASSWORD",
+  "hostname": "tepra"
 }

--- a/main.py
+++ b/main.py
@@ -180,7 +180,7 @@ async def main():
 
     while True:
         # Bring up the Wi-Fi (it will do nothing if it's already connected)
-        ok = wifi.up(conf['ssid'], conf['psk'])
+        ok = wifi.up(conf['ssid'], conf['psk'], conf['hostname'])
         if not ok:
             log('Failed to establish a Wi-Fi connection, resetting')
             machine.reset()

--- a/wifi.py
+++ b/wifi.py
@@ -7,7 +7,7 @@ log = new_logger('Wi-Fi  :')
 wifi = network.WLAN(network.STA_IF)
 
 
-def up(ssid, psk):
+def up(ssid, psk, hostname):
     if wifi.isconnected():
         return True
 
@@ -15,6 +15,7 @@ def up(ssid, psk):
     log('SSID: {}, PSK: (hidden)', ssid)
 
     wifi.active(True)
+    wifi.config(dhcp_hostname=hostname)
     wifi.connect(ssid, psk)
 
     elapsed = 0


### PR DESCRIPTION
MicroPython ESP32 port has a mDNS responder out-of-the-box. Now the hostname is set `tepra` by default so we can access it via `tepra.local` .