### PR TITLE
Support to Tepra's advertising name change

### DIFF
--- a/tepra.py
+++ b/tepra.py
@@ -200,7 +200,7 @@ class BLESimpleCentral:
                 str(bytes(adv_data)),
             )
 
-            if name.startswith('LR30'):
+            if name.startswith('LR30') or name.startswith('TepraBLE'):
                 # Found a potential device, remember it and stop scanning
                 self._addr_type = addr_type
                 self._addr = bytes(addr)  # Note: addr buffer is owned by caller so need to copy it


### PR DESCRIPTION
はじめまして、
手元の Tepra Lite LR30 で使わせていただいたところ、 BLE の広告名が変わっており( TepraBLE から始まる名前になっていた)、接続処理の条件分岐を変更する必要がありました。このPRはその修正となります。